### PR TITLE
Bump Version

### DIFF
--- a/tailscale/CHANGELOG.md
+++ b/tailscale/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.26.1.9 (forked)
+
+- Release unreleased changes from community add-on
+  - Update tailscale/tailscale to v1.92.4
+
 ## 0.26.1.8 (forked)
 
 - Release unreleased changes from community add-on

--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
 ARG BUILD_ARCH=amd64
-ARG TAILSCALE_VERSION="v1.92.3"
+ARG TAILSCALE_VERSION="v1.92.4"
 RUN \
     apk add --no-cache \
         bind-tools=9.20.16-r0 \

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Tailscale with features
-version: 0.26.1.8
+version: 0.26.1.9
 slug: tailscale
 description: Zero config VPN for building secure networks
 url: https://github.com/lmagyar/homeassistant-addon-tailscale


### PR DESCRIPTION
## 0.26.1.9 (forked)

- Release unreleased changes from community add-on
  - Update tailscale/tailscale to v1.92.4