### PR TITLE
Fix small typo in English translation

### DIFF
--- a/tailscale/translations/en.yaml
+++ b/tailscale/translations/en.yaml
@@ -35,7 +35,7 @@ configuration:
       The add-on by default will advertise routes to your subnets on all supported
       interfaces by adding `local_subnets` to the list.
   always_use_derp:
-    name: Alwas use DERP connection
+    name: Always use DERP connection
     description: >-
       When enabled forces all peer communication over DERP by disabling the use of
       UDP.


### PR DESCRIPTION
Just noticed this while installing the add-on. Thanks for the good work!