### PR TITLE
Add ha CLI support for Tailscale SSH sessions

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -8,6 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base
 ARG BUILD_ARCH=amd64
 ARG TAILSCALE_VERSION="v1.94.2"
+ARG HA_CLI_VERSION="4.46.0"
 RUN \
     apk add --no-cache \
         bind-tools=9.20.19-r0 \
@@ -32,7 +33,13 @@ RUN \
         | tar zxvf - -C /opt/ --strip-components 1 \
     \
     && rm -f -r \
-        /opt/systemd
+        /opt/systemd \
+    \
+    && curl -L -s -o /usr/bin/ha.bin \
+        "https://github.com/home-assistant/cli/releases/download/${HA_CLI_VERSION}/ha_${BUILD_ARCH}" \
+    && chmod a+x /usr/bin/ha.bin \
+    && printf '#!/bin/sh\nif [ -z "$SUPERVISOR_TOKEN" ] && [ -f /run/s6/container_environment/SUPERVISOR_TOKEN ]; then\n    export SUPERVISOR_TOKEN\n    SUPERVISOR_TOKEN=$(cat /run/s6/container_environment/SUPERVISOR_TOKEN)\nfi\nexec /usr/bin/ha.bin "$@"\n' > /usr/bin/ha \
+    && chmod a+x /usr/bin/ha
 
 # Copy root filesystem
 COPY rootfs /

--- a/tailscale/config.yaml
+++ b/tailscale/config.yaml
@@ -14,6 +14,7 @@ arch:
   - amd64
 init: false
 hassio_api: true
+hassio_role: manager
 homeassistant_api: true
 host_network: true
 host_dbus: true


### PR DESCRIPTION
## Summary
- Add `hassio_role: manager` to `config.yaml` for Supervisor management API access
- Install `ha` CLI binary in Dockerfile with a wrapper script that auto-loads `SUPERVISOR_TOKEN` from s6 container environment

## Problem
Tailscale SSH sessions cannot use the `ha` CLI because:
1. `hassio_role` defaults to `default`, blocking management endpoints (`/core/restart`, `/core/logs`) with 403 Forbidden
2. Tailscale SSH doesn't go through s6's `with-contenv`, so `SUPERVISOR_TOKEN` is not in the environment

## Solution
- Set `hassio_role: manager` (same as the Advanced SSH addon — does not require disabling protection mode)
- Install the official `ha` CLI binary and wrap it with a shell script that reads `SUPERVISOR_TOKEN` from `/run/s6/container_environment/SUPERVISOR_TOKEN` at runtime

## Test plan
- [x] `ha core logs` works via Tailscale SSH
- [x] `ha core restart` works via Tailscale SSH
- [x] All `ha` subcommands available
- [x] Tested on HAOS 17.1, HA 2026.3.2, aarch64 (RPi + Proxmox VM)

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)